### PR TITLE
Remove dependency on qemu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
@@ -63,6 +61,7 @@ jobs:
       with:
         # list of Docker images to use as base name for tags
         images: |
+          # TODO: change this
           nsheridan/cashier
         # Docker tags based on the following events/attributes
         tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM golang:latest as build
+FROM --platform=${BUILDPLATFORM} golang:latest AS build
 LABEL maintainer="nsheridan@gmail.com"
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /build
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux make install-cashierd
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} make cashierd
 
-FROM gcr.io/distroless/base
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/base
 LABEL maintainer="nsheridan@gmail.com"
-WORKDIR /cashier
-COPY --from=build /go/bin/cashierd /
+COPY --from=build /build/cashierd /
 ENTRYPOINT ["/cashierd"]


### PR DESCRIPTION
Following the removal of the CGO dependency, the container images can be built using Go's native cross-arch tooling without external emulation.

Using QEMU the container build step takes 9m 23s.
Using Go cross-compilation the container build step takes 1m 57s.