### PR TITLE
Speed up golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push]
 
 env:
   CGO_ENABLED: 0
+  GOTOOLCHAIN: local
   MYSQL_TEST: true
   MYSQL_TEST_USER: 'dbuser'
   MYSQL_TEST_PASS: 'dbpass'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,10 @@ on:
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read
 
+env:
+  CGO_ENABLED: 0
+  GOTOOLCHAIN: local
+
 jobs:
   golangci:
     permissions:
@@ -26,11 +30,11 @@ jobs:
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-      - name: Install snmp_exporter/generator dependencies
-        run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
-        if: github.repository == 'prometheus/snmp_exporter'
+      # Force a build and see if it speeds up the linter.
+      - name: Build
+        run: make build
       - name: Lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           args: --verbose
-          version: v1.60.2
+          version: v1.62.2

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,9 @@ SRC_FILES = $(shell find * -type f -name '*.go' -not -path 'vendor/*')
 VERSION_PKG := github.com/cashier-go/cashier/lib.Version
 VERSION := $(shell git describe --tags --always --dirty)
 
-GOTOOLCHAIN=local
-
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-CGO_ENABLED ?= $(shell go env CGO_ENABLED)
+CGO_ENABLED ?= 0
 
 ifeq ($(GOOS), linux)
   ifeq ($(CGO_ENABLED), 1)


### PR DESCRIPTION
golangci-lint routinely takes longer than the default 60s timeout. The bottleneck seems to be needing to compile the project as part of the lint operation - manually performing this step prior to running the linter helps matters.